### PR TITLE
 feat(Seed): Seed admin on app start

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,24 @@
+import bcrypt from "bcrypt";
+import { prisma } from "../src/utils/prismaClient.js";
+
+export async function seedAdmin() {
+    const existing = await prisma.user.findUnique({
+        where: { email: "admin@gmail.com" },
+    });
+
+    if (existing) return;
+
+    const hashedPassword = await bcrypt.hash("AdminPassword123", 10);
+
+    await prisma.user.create({
+        data: {
+            name: "Admin",
+            email: "admin@gmail.com",
+            password: hashedPassword,
+            phoneNumber: "0000000000",
+            role: "ADMIN",
+        },
+    });
+
+    console.log("Admin seeded successfully.");
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import { app } from "./app.js";
+import { seedAdmin } from "../prisma/seed.js";
 
 const PORT = process.env.PORT || 3000;
 
-app.listen(PORT, () => {
-    console.log(`listening on ${PORT}`);
-});
+await seedAdmin();
+app.listen(PORT, () => console.log(`listening on ${PORT}`));


### PR DESCRIPTION
 # Added a database seeding function to create an Admin .

```json
{
  "email": "admin@gmail.com",
  "password": "AdminPassword123"
}
```
<img width="1429" height="887" alt="Screenshot 2026-04-18 123811" src="https://github.com/user-attachments/assets/5102c1ab-001d-45ef-a69f-d84df64e55de" />
<img width="584" height="285" alt="Screenshot 2026-04-18 123535" src="https://github.com/user-attachments/assets/aca63df3-cb5c-4e51-b5aa-b932638cd57c" />
